### PR TITLE
Add simple CI usage documentation

### DIFF
--- a/docs/using-kubelinter.md
+++ b/docs/using-kubelinter.md
@@ -62,7 +62,7 @@ includes the following pre-commit hooks:
 
 ## Using KubeLinter as part of your CI pipeline
 
-If you're using Github, there's the [KubeLinter Github Action](README.md##kubelinter-github-action) available.
+If you're using GitHub, there's the [KubeLinter GitHub Action](README.md##kubelinter-github-action) available.
 
 Alternatively, you can grab the latest binary release with the following commands
 ```bash

--- a/docs/using-kubelinter.md
+++ b/docs/using-kubelinter.md
@@ -76,7 +76,7 @@ tar -xf kube-linter-linux.tar.gz -C "kube-linter/"
 ```
 and pass `--fail-on-invalid-resource` as an option to have your pipeline fail if your YAML file can't be parsed. See the following example:
 ```bash
-./kube-linter/kube-linter lint --fail-on-invalid-resource pod.yaml
+./kube-linter/kube-linter lint --fail-on-invalid-resource /path/to/yaml-file.yaml
 ```
 
 ## KubeLinter commands

--- a/docs/using-kubelinter.md
+++ b/docs/using-kubelinter.md
@@ -67,11 +67,12 @@ If you're using GitHub, there's the [KubeLinter GitHub Action](README.md#kubelin
 Alternatively, you can grab the latest binary release with the following commands
 ```bash
 LOCATION=$(curl -s https://api.github.com/repos/stackrox/kube-linter/releases/latest \
-| grep "tag_name" \
-| awk '{print "https://github.com/stackrox/kube-linter/releases/download/" substr($2, 2, length($2)-3) "/kube-linter-linux.tar.gz"}')
+| jq -r '.tag_name
+    | "https://github.com/stackrox/kube-linter/releases/download/\(.)/kube-linter-linux.tar.gz"')
 curl -L -o kube-linter-linux.tar.gz $LOCATION
 mkdir kube-linter/
 tar -xf kube-linter-linux.tar.gz -C "kube-linter/"
+
 ```
 and pass `--fail-on-invalid-resource` as an option to have your pipeline fail if your YAML file can't be parsed. See the following example:
 ```bash

--- a/docs/using-kubelinter.md
+++ b/docs/using-kubelinter.md
@@ -62,7 +62,7 @@ includes the following pre-commit hooks:
 
 ## Using KubeLinter as part of your CI pipeline
 
-If you're using GitHub, there's the [KubeLinter GitHub Action](README.md##kubelinter-github-action) available.
+If you're using GitHub, there's the [KubeLinter GitHub Action](README.md#kubelinter-github-action) available.
 
 Alternatively, you can grab the latest binary release with the following commands
 ```bash

--- a/docs/using-kubelinter.md
+++ b/docs/using-kubelinter.md
@@ -60,6 +60,24 @@ includes the following pre-commit hooks:
    - You must [install Docker](https://docs.docker.com/engine/install/) before
      running this pre-commit hook.
 
+## Using KubeLinter as part of your CI pipeline
+
+If you're using Github, there's the [KubeLinter Github Action](README.md##kubelinter-github-action) available.
+
+Alternatively, you can grab the latest binary release with the following commands
+```bash
+LOCATION=$(curl -s https://api.github.com/repos/stackrox/kube-linter/releases/latest \
+| grep "tag_name" \
+| awk '{print "https://github.com/stackrox/kube-linter/releases/download/" substr($2, 2, length($2)-3) "/kube-linter-linux.tar.gz"}')
+curl -L -o kube-linter-linux.tar.gz $LOCATION
+mkdir kube-linter/
+tar -xf kube-linter-linux.tar.gz -C "kube-linter/"
+```
+and pass `--fail-on-invalid-resource` as an option to have your pipeline fail if your YAML file can't be parsed. See the following example:
+```bash
+./kube-linter/kube-linter lint --fail-on-invalid-resource pod.yaml
+```
+
 ## KubeLinter commands
 
 This section covers kube-linter command syntax, describes the command


### PR DESCRIPTION
Hi,

I added some basic documentation for using KubeLinter as part of a CI pipeline. While there is a Github Action available, I might not be the only one interested in running it elsewhere. I found the `--fail-on-invalid-resource` option especially important when dealing with manual changes to YAML files.